### PR TITLE
feature/218

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,10 +19,10 @@ mail = Mail()
 sentry = Sentry()
 client = Client()
 
-if os.getenv('APP_SETTINGS', '') == 'prod':
-    config_env = ProdConfig
-else:
+if os.getenv('FLASK_ENV', '') == 'development':
     config_env = DevConfig
+else:
+    config_env = ProdConfig
 
 
 def create_app(config=config_env):

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,4 +5,4 @@ RUN mkdir /code
 WORKDIR /code
 ADD requirements.txt /code
 RUN pip install -r requirements.txt
-ADD . /code/
+ADD . /code

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -24,8 +24,7 @@ services:
         - DB_HOST=postgresql
         - DB_PORT=5432
         - DB_ENGINE=postgresql
-        - ENV=dev
-        - FLASK_DEBUG=1
+        - FLASK_ENV=development
     ports:
       - "5000:5000"
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,7 +25,6 @@ services:
         - DB_HOST=postgresql
         - DB_PORT=5432
         - DB_ENGINE=postgresql
-        - ENV=prod
     depends_on:
       - "postgresql"
     container_name: melvil_web_prod


### PR DESCRIPTION
PR related to issue #218 

- changing the environemnts for the app can be done easily with the feature supported by the Flask which is setting the FLASK_ENV as "development" for the app
- I've added this 'switch' in the `docker-compose-dev.yml` file - if invoked, it sets the env variable, flask launches as a development server, which automatically sets the `FLASK_DEBUG`  to `1` (debugging mode)
- `docker-compose.yml` does not contain this env variable, which means that `FLASK_ENV` is set to 'production'
- this way we get rid of extra environment variable from the compose file's called `ENV`
- the change of if-clause order for classes `DevConfig` and `ProdConfig` in `app.py` forced by the aforementioned changes with env variables